### PR TITLE
[SPARK-26089] Checking the shuffle transmitted data to handle large corrupt shuffle blocks

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/DigestFileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/DigestFileSegmentManagedBuffer.java
@@ -15,32 +15,36 @@
  * limitations under the License.
  */
 
-package org.apache.spark.network.shuffle;
+package org.apache.spark.network.buffer;
+
+import java.io.File;
+
+import com.google.common.base.Objects;
+
+import org.apache.spark.network.util.TransportConf;
 
 /**
- * Contains offset and length of the shuffle block data.
+ * A {@link ManagedBuffer} backed by a segment in a file with digest.
  */
-public class ShuffleIndexRecord {
-  private final long offset;
-  private final long length;
+public final class DigestFileSegmentManagedBuffer extends FileSegmentManagedBuffer {
+
   private final long digest;
 
-  public ShuffleIndexRecord(long offset, long length, long digest) {
-    this.offset = offset;
-    this.length = length;
+  public DigestFileSegmentManagedBuffer(TransportConf conf, File file, long offset, long length,
+    long digest) {
+    super(conf, file, offset, length);
     this.digest = digest;
   }
 
-  public long getOffset() {
-    return offset;
-  }
+  public long getDigest() { return digest; }
 
-  public long getLength() {
-    return length;
-  }
-
-  public long getDigest() {
-    return digest;
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("file", getFile())
+      .add("offset", getOffset())
+      .add("length", getLength())
+      .add("digest", digest)
+      .toString();
   }
 }
-

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -37,7 +37,7 @@ import org.apache.spark.network.util.TransportConf;
 /**
  * A {@link ManagedBuffer} backed by a segment in a file.
  */
-public final class FileSegmentManagedBuffer extends ManagedBuffer {
+public class FileSegmentManagedBuffer extends ManagedBuffer {
   private final TransportConf conf;
   private final File file;
   private final long offset;

--- a/common/network-common/src/main/java/org/apache/spark/network/client/ChunkReceivedCallback.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/ChunkReceivedCallback.java
@@ -36,6 +36,11 @@ public interface ChunkReceivedCallback {
    */
   void onSuccess(int chunkIndex, ManagedBuffer buffer);
 
+  /** Called with a extra digest parameter upon receipt of a particular chunk.*/
+  default void onSuccess(int chunkIndex, ManagedBuffer buffer, long digest) {
+    onSuccess(chunkIndex, buffer);
+  }
+
   /**
    * Called upon failure to fetch a particular chunk. Note that this may actually be called due
    * to failure to fetch a prior chunk in this stream.

--- a/common/network-common/src/main/java/org/apache/spark/network/client/StreamCallback.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/StreamCallback.java
@@ -35,6 +35,11 @@ public interface StreamCallback {
   /** Called when all data from the stream has been received. */
   void onComplete(String streamId) throws IOException;
 
+  /** Called with a extra digest when all data from the stream has been received. */
+  default void onComplete(String streamId, long digest) throws IOException {
+    onComplete(streamId);
+  }
+
   /** Called if there's an error reading data from the stream. */
   void onFailure(String streamId, Throwable cause) throws IOException;
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/client/StreamInterceptor.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/StreamInterceptor.java
@@ -37,6 +37,7 @@ public class StreamInterceptor<T extends Message> implements TransportFrameDecod
   private final long byteCount;
   private final StreamCallback callback;
   private long bytesRead;
+  private long digest = -1L;
 
   public StreamInterceptor(
       MessageHandler<T> handler,
@@ -48,6 +49,16 @@ public class StreamInterceptor<T extends Message> implements TransportFrameDecod
     this.byteCount = byteCount;
     this.callback = callback;
     this.bytesRead = 0;
+  }
+
+  public StreamInterceptor(
+      MessageHandler<T> handler,
+      String streamId,
+      long byteCount,
+      StreamCallback callback,
+      long digest) {
+    this(handler, streamId, byteCount, callback);
+    this.digest = digest;
   }
 
   @Override
@@ -86,7 +97,11 @@ public class StreamInterceptor<T extends Message> implements TransportFrameDecod
       throw re;
     } else if (bytesRead == byteCount) {
       deactivateStream();
-      callback.onComplete(streamId);
+      if (digest < 0) {
+        callback.onComplete(streamId);
+      } else {
+        callback.onComplete(streamId, digest);
+      }
     }
 
     return bytesRead != byteCount;

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -33,6 +33,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.protocol.ChunkFetchFailure;
 import org.apache.spark.network.protocol.ChunkFetchSuccess;
+import org.apache.spark.network.protocol.DigestChunkFetchSuccess;
+import org.apache.spark.network.protocol.DigestStreamResponse;
 import org.apache.spark.network.protocol.ResponseMessage;
 import org.apache.spark.network.protocol.RpcFailure;
 import org.apache.spark.network.protocol.RpcResponse;
@@ -245,6 +247,45 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
         }
       } else {
         logger.warn("Stream failure with unknown callback: {}", resp.error);
+      }
+    } else if (message instanceof DigestChunkFetchSuccess) {
+      DigestChunkFetchSuccess resp = (DigestChunkFetchSuccess) message;
+      ChunkReceivedCallback listener = outstandingFetches.get(resp.streamChunkId);
+      if (listener == null) {
+        logger.warn("Ignoring response for block {} from {} since it is not outstanding",
+                resp.streamChunkId, getRemoteAddress(channel));
+        resp.body().release();
+      } else {
+        outstandingFetches.remove(resp.streamChunkId);
+        listener.onSuccess(resp.streamChunkId.chunkIndex, resp.body(), resp.digest);
+        resp.body().release();
+      }
+    } else if (message instanceof DigestStreamResponse) {
+      DigestStreamResponse resp = (DigestStreamResponse) message;
+      Pair<String, StreamCallback> entry = streamCallbacks.poll();
+      if (entry != null) {
+        StreamCallback callback = entry.getValue();
+        if (resp.byteCount > 0) {
+          StreamInterceptor interceptor = new StreamInterceptor(this, resp.streamId, resp.byteCount,
+                  callback, resp.digest);
+          try {
+            TransportFrameDecoder frameDecoder = (TransportFrameDecoder)
+                    channel.pipeline().get(TransportFrameDecoder.HANDLER_NAME);
+            frameDecoder.setInterceptor(interceptor);
+            streamActive = true;
+          } catch (Exception e) {
+            logger.error("Error installing stream handler.", e);
+            deactivateStream();
+          }
+        } else {
+          try {
+            callback.onComplete(resp.streamId, resp.digest);
+          } catch (Exception e) {
+            logger.warn("Error in stream handler onComplete().", e);
+          }
+        }
+      } else {
+        logger.error("Could not find callback for StreamResponse.");
       }
     } else {
       throw new IllegalStateException("Unknown response type: " + message.type());

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestChunkFetchSuccess.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestChunkFetchSuccess.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.buffer.NettyManagedBuffer;
+
+/**
+ * Response to {@link ChunkFetchRequest} when a chunk exists with a digest and has been
+ * successfully fetched.
+ *
+ * Note that the server-side encoding of this messages does NOT include the buffer itself, as this
+ * may be written by Netty in a more efficient manner (i.e., zero-copy write).
+ * Similarly, the client-side decoding will reuse the Netty ByteBuf as the buffer.
+ */
+public final class DigestChunkFetchSuccess extends AbstractResponseMessage {
+  public final StreamChunkId streamChunkId;
+  public final long digest;
+  public DigestChunkFetchSuccess(StreamChunkId streamChunkId, ManagedBuffer buffer, long digest) {
+    super(buffer, true);
+    this.streamChunkId = streamChunkId;
+    this.digest = digest;
+  }
+
+  @Override
+  public Type type() { return Type.DigestChunkFetchSuccess; }
+
+  @Override
+  public int encodedLength() {
+    return streamChunkId.encodedLength() + 8;
+  }
+
+  /** Encoding does NOT include 'buffer' itself. See {@link MessageEncoder}. */
+  @Override
+  public void encode(ByteBuf buf) {
+    streamChunkId.encode(buf);
+    buf.writeLong(digest);
+  }
+
+  @Override
+  public ResponseMessage createFailureResponse(String error) {
+    return new ChunkFetchFailure(streamChunkId, error);
+  }
+
+  /** Decoding uses the given ByteBuf as our data, and will retain() it. */
+  public static DigestChunkFetchSuccess decode(ByteBuf buf) {
+    StreamChunkId streamChunkId = StreamChunkId.decode(buf);
+    long digest = buf.readLong();
+    buf.retain();
+    NettyManagedBuffer managedBuf = new NettyManagedBuffer(buf.duplicate());
+    return new DigestChunkFetchSuccess(streamChunkId, managedBuf, digest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(streamChunkId, body(), digest);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof DigestChunkFetchSuccess) {
+      DigestChunkFetchSuccess o = (DigestChunkFetchSuccess) other;
+      return streamChunkId.equals(o.streamChunkId) && super.equals(o) && digest == o.digest;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("streamChunkId", streamChunkId)
+      .add("digest", digest)
+      .add("buffer", body())
+      .toString();
+  }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestStreamResponse.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/DigestStreamResponse.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import org.apache.spark.network.buffer.ManagedBuffer;
+
+/**
+ * Response to {@link StreamRequest} with digest when the stream has been successfully opened.
+ * <p>
+ * Note the message itself does not contain the stream data. That is written separately by the
+ * sender. The receiver is expected to set a temporary channel handler that will consume the
+ * number of bytes this message says the stream has.
+ */
+public final class DigestStreamResponse extends AbstractResponseMessage {
+  public final String streamId;
+  public final long byteCount;
+  public final long digest;
+
+  public DigestStreamResponse(String streamId, long byteCount, ManagedBuffer buffer, long digest) {
+    super(buffer, false);
+    this.streamId = streamId;
+    this.byteCount = byteCount;
+    this.digest = digest;
+  }
+
+  @Override
+  public Type type() { return Type.DigestStreamResponse; }
+
+  @Override
+  public int encodedLength() {
+    return 8 + Encoders.Strings.encodedLength(streamId) + 8;
+  }
+
+  /** Encoding does NOT include 'buffer' itself. See {@link MessageEncoder}. */
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, streamId);
+    buf.writeLong(byteCount);
+    buf.writeLong(digest);
+  }
+
+  @Override
+  public ResponseMessage createFailureResponse(String error) {
+    return new StreamFailure(streamId, error);
+  }
+
+  public static DigestStreamResponse decode(ByteBuf buf) {
+    String streamId = Encoders.Strings.decode(buf);
+    long byteCount = buf.readLong();
+    long digest = buf.readLong();
+    return new DigestStreamResponse(streamId, byteCount, null, digest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(byteCount, streamId, body(), digest);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof DigestStreamResponse) {
+      DigestStreamResponse o = (DigestStreamResponse) other;
+      return byteCount == o.byteCount && streamId.equals(o.streamId) && digest == o.digest;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("streamId", streamId)
+      .add("byteCount", byteCount)
+      .add("digest", digest)
+      .add("body", body())
+      .toString();
+  }
+
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/Message.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/Message.java
@@ -37,7 +37,8 @@ public interface Message extends Encodable {
     ChunkFetchRequest(0), ChunkFetchSuccess(1), ChunkFetchFailure(2),
     RpcRequest(3), RpcResponse(4), RpcFailure(5),
     StreamRequest(6), StreamResponse(7), StreamFailure(8),
-    OneWayMessage(9), UploadStream(10), User(-1);
+    OneWayMessage(9), UploadStream(10), DigestChunkFetchSuccess(11),
+    DigestStreamResponse(12), User(-1);
 
     private final byte id;
 
@@ -66,6 +67,8 @@ public interface Message extends Encodable {
         case 8: return StreamFailure;
         case 9: return OneWayMessage;
         case 10: return UploadStream;
+        case 11: return DigestChunkFetchSuccess;
+        case 12: return DigestStreamResponse;
         case -1: throw new IllegalArgumentException("User type messages cannot be decoded.");
         default: throw new IllegalArgumentException("Unknown message type: " + id);
       }

--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageDecoder.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageDecoder.java
@@ -50,6 +50,12 @@ public final class MessageDecoder extends MessageToMessageDecoder<ByteBuf> {
 
   private Message decode(Message.Type msgType, ByteBuf in) {
     switch (msgType) {
+      case DigestChunkFetchSuccess:
+        return DigestChunkFetchSuccess.decode(in);
+
+      case DigestStreamResponse:
+        return DigestStreamResponse.decode(in);
+
       case ChunkFetchRequest:
         return ChunkFetchRequest.decode(in);
 

--- a/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java
@@ -25,15 +25,13 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer;
+import org.apache.spark.network.protocol.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.TransportClient;
-import org.apache.spark.network.protocol.ChunkFetchFailure;
-import org.apache.spark.network.protocol.ChunkFetchRequest;
-import org.apache.spark.network.protocol.ChunkFetchSuccess;
-import org.apache.spark.network.protocol.Encodable;
 
 import static org.apache.spark.network.util.NettyUtils.*;
 
@@ -100,8 +98,16 @@ public class ChunkFetchRequestHandler extends SimpleChannelInboundHandler<ChunkF
     }
 
     streamManager.chunkBeingSent(msg.streamChunkId.streamId);
-    respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
-      (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+    if (buf instanceof DigestFileSegmentManagedBuffer) {
+      respond(channel, new DigestChunkFetchSuccess(msg.streamChunkId, buf,
+              ((DigestFileSegmentManagedBuffer)buf).getDigest()))
+              .addListener((ChannelFutureListener) future ->
+                      streamManager.chunkSent(msg.streamChunkId.streamId));
+    } else {
+      respond(channel, new ChunkFetchSuccess(msg.streamChunkId, buf)).addListener(
+              (ChannelFutureListener) future -> streamManager.chunkSent(msg.streamChunkId.streamId));
+    }
+
   }
 
   /**

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DigestUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.CRC32;
+
+public class DigestUtils {
+    private static final int STREAM_BUFFER_LENGTH = 2048;
+    private static final int DIGEST_LENGTH = 8;
+
+    public static int getDigestLength() {
+       return DIGEST_LENGTH;
+    }
+
+    public DigestUtils() {
+    }
+
+    public static long getDigest(InputStream data) throws IOException {
+        return updateCRC32(getCRC32(), data);
+    }
+
+    public static CRC32 getCRC32() {
+        return new CRC32();
+    }
+
+    public static long updateCRC32(CRC32 crc32, InputStream data) throws IOException {
+        byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
+        int len = 0;
+        while ((len = data.read(buffer)) >= 0) {
+            crc32.update(buffer, 0, len);
+        }
+        return crc32.getValue();
+    }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockFetchingListener.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockFetchingListener.java
@@ -30,6 +30,15 @@ public interface BlockFetchingListener extends EventListener {
   void onBlockFetchSuccess(String blockId, ManagedBuffer data);
 
   /**
+   * Called once per successfully fetch block during shuffle, which has a parameter present the
+   * checkSum of shuffle block. Here provide a default method body for that not every
+   * blockFetchingListener need to implement one onBlockFetchSuccess method.
+   */
+  default void onBlockFetchSuccess(String blockId, ManagedBuffer data, long digest) {
+    onBlockFetchSuccess(blockId, data);
+  }
+
+  /**
    * Called at least once per block upon failures.
    */
   void onBlockFetchFailure(String blockId, Throwable exception);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -42,6 +42,7 @@ import org.iq80.leveldb.DBIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
@@ -287,12 +288,23 @@ public class ExternalShuffleBlockResolver {
     try {
       ShuffleIndexInformation shuffleIndexInformation = shuffleIndexCache.get(indexFile);
       ShuffleIndexRecord shuffleIndexRecord = shuffleIndexInformation.getIndex(reduceId);
-      return new FileSegmentManagedBuffer(
-        conf,
-        getFile(executor.localDirs, executor.subDirsPerLocalDir,
+      if (shuffleIndexInformation.isHasDigest()) {
+        return new DigestFileSegmentManagedBuffer(
+          conf,
+          getFile(executor.localDirs, executor.subDirsPerLocalDir,
           "shuffle_" + shuffleId + "_" + mapId + "_0.data"),
-        shuffleIndexRecord.getOffset(),
-        shuffleIndexRecord.getLength());
+          shuffleIndexRecord.getOffset(),
+          shuffleIndexRecord.getLength(),
+          shuffleIndexRecord.getDigest());
+
+      } else {
+        return new FileSegmentManagedBuffer(
+          conf,
+          getFile(executor.localDirs, executor.subDirsPerLocalDir,
+          "shuffle_" + shuffleId + "_" + mapId + "_0.data"),
+          shuffleIndexRecord.getOffset(),
+          shuffleIndexRecord.getLength());
+      }
     } catch (ExecutionException e) {
       throw new RuntimeException("Failed to open file: " + indexFile, e);
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockFetcher.java
@@ -93,6 +93,12 @@ public class OneForOneBlockFetcher {
     }
 
     @Override
+    public void onSuccess(int chunkIndex, ManagedBuffer buffer, long digest) {
+      // On receipt of a chunk, pass it upwards as a block.
+      listener.onBlockFetchSuccess(blockIds[chunkIndex], buffer, digest);
+    }
+
+    @Override
     public void onFailure(int chunkIndex, Throwable e) {
       // On receipt of a failure, fail every block from chunkIndex onwards.
       String[] remainingBlockIds = Arrays.copyOfRange(blockIds, chunkIndex, blockIds.length);
@@ -174,6 +180,14 @@ public class OneForOneBlockFetcher {
     @Override
     public void onComplete(String streamId) throws IOException {
       listener.onBlockFetchSuccess(blockIds[chunkIndex], channel.closeAndRead());
+      if (!downloadFileManager.registerTempFileToClean(targetFile)) {
+        targetFile.delete();
+      }
+    }
+
+    @Override
+    public void onComplete(String streamId, long digest) throws IOException {
+      listener.onBlockFetchSuccess(blockIds[chunkIndex], channel.closeAndRead(), digest);
       if (!downloadFileManager.registerTempFileToClean(targetFile)) {
         targetFile.delete();
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleIndexInformation.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleIndexInformation.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.nio.file.Files;
 
+import org.apache.spark.network.util.DigestUtils;
+
 /**
  * Keeps the index information for a particular map output
  * as an in-memory LongBuffer.
@@ -31,15 +33,46 @@ import java.nio.file.Files;
 public class ShuffleIndexInformation {
   /** offsets as long buffer */
   private final LongBuffer offsets;
+  private final boolean hasDigest;
+  /** digests as long buffer */
+  private final LongBuffer digests;
   private int size;
 
   public ShuffleIndexInformation(File indexFile) throws IOException {
-    size = (int)indexFile.length();
-    ByteBuffer buffer = ByteBuffer.allocate(size);
-    offsets = buffer.asLongBuffer();
-    try (DataInputStream dis = new DataInputStream(Files.newInputStream(indexFile.toPath()))) {
-      dis.readFully(buffer.array());
+    ByteBuffer offsetsBuffer, digestsBuffer;
+    if (indexFile.length() % 8 == 0) {
+      hasDigest = false;
+      size = (int)indexFile.length();
+      offsetsBuffer = ByteBuffer.allocate(size);
+      offsets = offsetsBuffer.asLongBuffer();
+      digestsBuffer = ByteBuffer.allocate(0);
+      digests = digestsBuffer.asLongBuffer();
+    } else {
+      // this is a indexDigest file
+      hasDigest = true;
+      size = (int)indexFile.length() - 1;
+      int digestLength = DigestUtils.getDigestLength();
+      int blocks = (size - 8) / (8 + digestLength);
+      offsetsBuffer = ByteBuffer.allocate((blocks + 1) * 8);
+      offsets = offsetsBuffer.asLongBuffer();
+      digestsBuffer = ByteBuffer.allocate(blocks * 8);
+      digests = digestsBuffer.asLongBuffer();
     }
+    try (DataInputStream dis = new DataInputStream(Files.newInputStream(indexFile.toPath()))) {
+      if (hasDigest) {
+        // The flag in head
+        dis.readByte();
+      }
+      dis.readFully(offsetsBuffer.array());
+      dis.readFully(digestsBuffer.array());
+    }
+  }
+
+  /**
+   * If this indexFile has digest
+   */
+  public boolean isHasDigest() {
+    return hasDigest;
   }
 
   /**
@@ -56,6 +89,8 @@ public class ShuffleIndexInformation {
   public ShuffleIndexRecord getIndex(int reduceId) {
     long offset = offsets.get(reduceId);
     long nextOffset = offsets.get(reduceId + 1);
-    return new ShuffleIndexRecord(offset, nextOffset - offset);
+    /** Default digest is -1L.*/
+    long digest = hasDigest ? digests.get(reduceId) : -1L;
+    return new ShuffleIndexRecord(offset, nextOffset - offset, digest);
   }
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1309,4 +1309,10 @@ package object config {
     .bytesConf(ByteUnit.BYTE)
     .createOptional
 
+  private[spark] val SHUFFLE_DIGEST_ENABLE =
+    ConfigBuilder("spark.shuffle.digest.enable")
+      .internal()
+      .doc("The parameter to control whether check the transmitted data during shuffle.")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -56,6 +56,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
       SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
+      SparkEnv.get.conf.get(config.SHUFFLE_DIGEST_ENABLE),
       readMetrics).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -24,8 +24,9 @@ import java.nio.file.Files
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.Logging
 import org.apache.spark.io.NioBufferedFileInputStream
-import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
+import org.apache.spark.network.buffer.{DigestFileSegmentManagedBuffer, FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.netty.SparkTransportConf
+import org.apache.spark.network.util.{DigestUtils, LimitedInputStream}
 import org.apache.spark.shuffle.IndexShuffleBlockResolver.NOOP_REDUCE_ID
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -50,6 +51,10 @@ private[spark] class IndexShuffleBlockResolver(
   private lazy val blockManager = Option(_blockManager).getOrElse(SparkEnv.get.blockManager)
 
   private val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle")
+
+  // The digest conf for shuffle block check
+  private final val digestEnable = conf.getBoolean("spark.shuffle.digest.enable", false);
+  private final val digestLength = DigestUtils.getDigestLength()
 
   def getDataFile(shuffleId: Int, mapId: Int): File = {
     blockManager.diskBlockManager.getFile(ShuffleDataBlockId(shuffleId, mapId, NOOP_REDUCE_ID))
@@ -82,12 +87,16 @@ private[spark] class IndexShuffleBlockResolver(
    * Check whether the given index and data files match each other.
    * If so, return the partition lengths in the data file. Otherwise return null.
    */
-  private def checkIndexAndDataFile(index: File, data: File, blocks: Int): Array[Long] = {
-    // the index file should have `block + 1` longs as offset.
-    if (index.length() != (blocks + 1) * 8L) {
+  private def checkIndexAndDataFile(index: File, data: File, blocks: Int, digests: Array[Long]):
+  (Array[Long], Array[Long]) = {
+    // Id digestEnable is false, the index file should have `blocks + 1` longs as offset.
+    // Otherwise, it should have a byte as flag, `blocks + 1` longs as offset and `blocks` digests
+    if ((!digestEnable && index.length() != (blocks + 1) * 8L) ||
+      (digestEnable && index.length() != blocks * (8L + digestLength) + 8L + 1L)) {
       return null
     }
     val lengths = new Array[Long](blocks)
+    val digestArr = new Array[Long](blocks)
     // Read the lengths of blocks
     val in = try {
       new DataInputStream(new NioBufferedFileInputStream(index))
@@ -97,6 +106,13 @@ private[spark] class IndexShuffleBlockResolver(
     }
     try {
       // Convert the offsets into lengths of each block
+      if (digestEnable) {
+        val flag = in.readByte()
+        // the flag for digestEnable should be 1
+        if (flag != 1) {
+          return null
+        }
+      }
       var offset = in.readLong()
       if (offset != 0L) {
         return null
@@ -108,6 +124,13 @@ private[spark] class IndexShuffleBlockResolver(
         offset = off
         i += 1
       }
+      if (digestEnable) {
+        i = 0
+        while (i < blocks) {
+          digestArr(i) = in.readLong()
+          i += 1
+        }
+      }
     } catch {
       case e: IOException =>
         return null
@@ -116,8 +139,8 @@ private[spark] class IndexShuffleBlockResolver(
     }
 
     // the size of data file should match with index file
-    if (data.length() == lengths.sum) {
-      lengths
+    if (data.length() == lengths.sum && !(0 until blocks).exists(i => digests(i) != digestArr(i))) {
+      (lengths, digestArr)
     } else {
       null
     }
@@ -141,15 +164,62 @@ private[spark] class IndexShuffleBlockResolver(
     val indexFile = getIndexFile(shuffleId, mapId)
     val indexTmp = Utils.tempFileWith(indexFile)
     try {
+      val out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(indexTmp)))
+      val dataIn = if (dataTmp != null && dataTmp.exists()) {
+        new FileInputStream(dataTmp)
+      } else {
+        null
+      }
+      val digests = new Array[Long](lengths.length)
+      Utils.tryWithSafeFinally {
+        if (digestEnable) {
+          // we write a byte present digest enable
+          out.writeByte(1)
+        }
+        // We take in lengths of each block, need to convert it to offsets.
+        var offset = 0L
+        out.writeLong(offset)
+        for (length <- lengths) {
+          offset += length
+          out.writeLong(offset)
+        }
+        if (digestEnable) {
+          for (i <- (0 until lengths.length)) {
+            val length = lengths(i)
+            if (length == 0 || dataIn == null) {
+              digests(i) = -1L
+              out.writeLong(-1L)
+            } else {
+              try {
+                val digest = DigestUtils.getDigest(new LimitedInputStream(dataIn, length))
+                digests(i) = digest
+                out.writeLong(digest)
+              } catch {
+                case e: IOException =>
+                  logError(s"Error occured when computing digest for $dataTmp", e)
+              }
+            }
+          }
+        }
+      } {
+        if (dataIn != null) {
+          dataIn.close()
+        }
+        out.close()
+      }
       val dataFile = getDataFile(shuffleId, mapId)
       // There is only one IndexShuffleBlockResolver per executor, this synchronization make sure
       // the following check and rename are atomic.
       synchronized {
-        val existingLengths = checkIndexAndDataFile(indexFile, dataFile, lengths.length)
-        if (existingLengths != null) {
+        val existingLengthsDigests = checkIndexAndDataFile(indexFile, dataFile, lengths.length,
+          digests)
+        if (existingLengthsDigests != null) {
           // Another attempt for the same task has already written our map outputs successfully,
           // so just use the existing partition lengths and delete our temporary map outputs.
+          val existingLengths = existingLengthsDigests._1
+          val existingDigests = existingLengthsDigests._2
           System.arraycopy(existingLengths, 0, lengths, 0, lengths.length)
+          System.arraycopy(existingDigests, 0, digests, 0, digests.length)
           if (dataTmp != null && dataTmp.exists()) {
             dataTmp.delete()
           }
@@ -202,22 +272,46 @@ private[spark] class IndexShuffleBlockResolver(
     // class of issue from re-occurring in the future which is why they are left here even though
     // SPARK-22982 is fixed.
     val channel = Files.newByteChannel(indexFile.toPath)
-    channel.position(blockId.reduceId * 8L)
+    var preOffset = 0
+    var blocks = (indexFile.length() - 8) / 8
+    if (digestEnable) {
+      preOffset = 1
+      blocks = (indexFile.length() - 1 - 8) / (8 + digestLength)
+    }
+    channel.position(preOffset + blockId.reduceId * 8L)
     val in = new DataInputStream(Channels.newInputStream(channel))
     try {
       val offset = in.readLong()
       val nextOffset = in.readLong()
       val actualPosition = channel.position()
-      val expectedPosition = blockId.reduceId * 8L + 16
+      val expectedPosition = blockId.reduceId * 8L + 16 + preOffset
       if (actualPosition != expectedPosition) {
         throw new Exception(s"SPARK-22982: Incorrect channel position after index file reads: " +
           s"expected $expectedPosition but actual position was $actualPosition.")
       }
-      new FileSegmentManagedBuffer(
-        transportConf,
-        getDataFile(blockId.shuffleId, blockId.mapId),
-        offset,
-        nextOffset - offset)
+      if (digestEnable) {
+        channel.position(preOffset + (blocks + 1) * 8L + blockId.reduceId * digestLength)
+        val digest = in.readLong()
+        val actualDigestPosition = channel.position()
+        val expectedDigestLength = preOffset + (blocks + 1) * 8L +
+          (blockId.reduceId + 1) * digestLength
+        if (actualDigestPosition != expectedDigestLength) {
+          throw new Exception(s"SPARK-22982: Incorrect channel position after index file reads: " +
+            s"expected $expectedDigestLength but actual position was $actualDigestPosition.")
+        }
+        new DigestFileSegmentManagedBuffer(
+          transportConf,
+          getDataFile(blockId.shuffleId, blockId.mapId),
+          offset,
+          nextOffset - offset,
+          digest)
+      } else {
+        new FileSegmentManagedBuffer(
+          transportConf,
+          getDataFile(blockId.shuffleId, blockId.mapId),
+          offset,
+          nextOffset - offset)
+      }
     } finally {
       in.close()
     }

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -412,6 +412,22 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
 
     manager.unregisterShuffle(0)
   }
+
+  test("[SPARK-26089]: test shuffle with digest enable") {
+      conf.set("spark.shuffle.digest.enable", "true")
+      val sc = new SparkContext("local", "test", conf)
+      val numRecords = 10000
+
+      val wordCount = sc.parallelize(1 to numRecords, 4)
+        .map(key => (key, 1))
+        .reduceByKey(_ + _)
+        .collect()
+      val count = wordCount.length
+      val sum = wordCount.map(value => value._1).sum
+      assert(count == numRecords)
+      assert(sum == (1 to numRecords).sum)
+      sc.stop()
+    }
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.shuffle.sort
 
-import java.io.{DataInputStream, File, FileInputStream, FileOutputStream}
+import java.io.{ByteArrayInputStream, DataInputStream, File, FileInputStream, FileOutputStream}
 
 import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
@@ -27,6 +27,8 @@ import org.mockito.invocation.InvocationOnMock
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.network.buffer.DigestFileSegmentManagedBuffer
+import org.apache.spark.network.util.DigestUtils
 import org.apache.spark.shuffle.IndexShuffleBlockResolver
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -155,4 +157,26 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
       indexIn2.close()
     }
   }
+
+  test("[SPARK-26089]: check the digest when digest is enable") {
+    val confClone = conf.clone
+    confClone.set("spark.shuffle.digest.enable", "true")
+    val resolver = new IndexShuffleBlockResolver(confClone, blockManager)
+    val lengths = Array[Long](10, 0, 20)
+    val dataTmp = File.createTempFile("shuffle", null, tempDir)
+    val out = new FileOutputStream(dataTmp)
+    Utils.tryWithSafeFinally {
+      out.write(new Array[Byte](30))
+    } {
+      out.close()
+    }
+    val digest = DigestUtils.getDigest(new ByteArrayInputStream(new Array[Byte](10)))
+
+    resolver.writeIndexFileAndCommit(1, 2, lengths, dataTmp)
+    val managedBuffer = resolver.getBlockData(ShuffleBlockId(1, 2, 0))
+    assert(managedBuffer.isInstanceOf[DigestFileSegmentManagedBuffer])
+    assert(managedBuffer.asInstanceOf[DigestFileSegmentManagedBuffer].getDigest == digest)
+
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -117,6 +117,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      false,
       metrics)
 
     // 3 local blocks fetched in initialization
@@ -195,6 +196,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     verify(blocks(ShuffleBlockId(0, 0, 0)), times(0)).release()
@@ -262,6 +264,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       false,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
 
@@ -320,6 +323,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
@@ -410,6 +414,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // Continue only after the mock calls onBlockFetchFailure
@@ -480,6 +485,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
     // We'll get back the block which has corruption after maxBytesInFlight/3 because the other
@@ -544,6 +550,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       true,
       true,
+      false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
     val (id, st) = iterator.next()
     // Check that the test setup is correct -- make sure we have a concatenated stream.
@@ -604,6 +611,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 
@@ -666,6 +674,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         maxReqSizeShuffleToMem = 200,
         detectCorrupt = true,
         false,
+        false,
         taskContext.taskMetrics.createTempShuffleReadMetrics())
     }
 
@@ -713,6 +722,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       Int.MaxValue,
       Int.MaxValue,
       true,
+      false,
       false,
       taskContext.taskMetrics.createTempShuffleReadMetrics())
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -772,6 +772,37 @@ Apart from these, the following properties are also available, and may be useful
     When we fail to register to the external shuffle service, we will retry for maxAttempts times.
   </td>
 </tr>
+<tr>
+  <td><code>spark.shuffle.digest.enable</code></td>
+  <td>false</td>
+  <td>
+    The parameter to control whether check the transmitted data during shuffle.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.io.encryption.enabled</code></td>
+  <td>false</td>
+  <td>
+    Enable IO encryption. Currently supported by all modes except Mesos. It's recommended that RPC encryption
+    be enabled when using this feature.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.io.encryption.keySizeBits</code></td>
+  <td>128</td>
+  <td>
+    IO encryption key size in bits. Supported values are 128, 192 and 256.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.io.encryption.keygen.algorithm</code></td>
+  <td>HmacSHA1</td>
+  <td>
+    The algorithm to use when generating the IO encryption key. The supported algorithms are
+    described in the KeyGenerator section of the Java Cryptography Architecture Standard Algorithm
+    Name Documentation.
+  </td>
+</tr>
 </table>
 
 ### Spark UI


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are some problems with the current shuffle transmitted data verification mechanism:
- only detect the compressed or wrapped data.
- only check the first maxBytesInFlight/3 bytes.
- need additional memory.


In this PR,  we compute the digest(crc32 value) for each partition of partitioned file in shuffle write phase, then we store these digests in shuffle index file.

In shuffle read phase, the digest value will be passed with the block data.
And we will recompute the digest of the data obtained to compare with the origin digest value.
When recomputing the digest of data obtained, it only need a buffer(2MB) for computing crc32 value.
After recomputing, we will reset the obtained data inputStream, if it is markSupported we only need reset it, otherwise it is a fileSegmentManagerBuffer, we need recreate it.

## How was this patch tested?
Unit test.
